### PR TITLE
PHP 7.0 compatibility and depreciations of incompatible annotations

### DIFF
--- a/Annotation/Compare/DateTime.php
+++ b/Annotation/Compare/DateTime.php
@@ -2,8 +2,10 @@
 
 namespace Ibrows\ImportBundle\Annotation\Compare;
 
+@trigger_error('The '.__NAMESPACE__.'\DateTime annotation is deprecated since version 1.3 and will be removed in 2.0. Use the Field annotation instead.', E_USER_DEPRECATED);
 /**
  * @Annotation
+ * @deprecated since version 1.3, to be removed in 2.0. Use the Field annotation instead
  */
 class DateTime extends AbstractCompare
 {

--- a/Annotation/Compare/Decimal.php
+++ b/Annotation/Compare/Decimal.php
@@ -2,8 +2,11 @@
 
 namespace Ibrows\ImportBundle\Annotation\Compare;
 
+@trigger_error('The '.__NAMESPACE__.'\Decimal annotation is deprecated since version 1.3 and will be removed in 2.0. Use the Field annotation instead.', E_USER_DEPRECATED);
+
 /**
  * @Annotation
+ * @deprecated since version 1.3, to be removed in 2.0. Use the Field annotation instead
  */
 class Decimal extends AbstractCompare
 {

--- a/Annotation/Compare/Double.php
+++ b/Annotation/Compare/Double.php
@@ -2,8 +2,11 @@
 
 namespace Ibrows\ImportBundle\Annotation\Compare;
 
+@trigger_error('The '.__NAMESPACE__.'\Double annotation is deprecated since version 1.3 and will be removed in 2.0. Use the Field annotation instead.', E_USER_DEPRECATED);
+
 /**
  * @Annotation
+ * @deprecated since version 1.3, to be removed in 2.0. Use the Field annotation instead
  */
 class Double extends AbstractCompare
 {

--- a/Annotation/Compare/Field.php
+++ b/Annotation/Compare/Field.php
@@ -1,12 +1,11 @@
 <?php
 
-namespace Ibrows\ImportBundle\Annotation\Mapping;
+namespace Ibrows\ImportBundle\Annotation\Compare;
 
 /**
  * @Annotation
- * @Target({"PROPERTY"})
  */
-class Field extends AbstractMapping
+class Field extends AbstractCompare
 {
     /**
      * @Required
@@ -54,15 +53,8 @@ class Field extends AbstractMapping
         $this->type = $type;
     }
 
-    public function transformToPHP($value)
-    {
-        $class = '\Ibrows\ImportBundle\Converter\\' . ucfirst($this->type) . 'Converter';
-        $obj = new $class();
-        return $obj->transformToPHP($value, $this);
-    }
-
-    public function transformToCompare($value)
-    {
+    public function  transformToCompare($value){
+        //proxy of mapping
         $class = '\Ibrows\ImportBundle\Converter\\' . ucfirst($this->type) . 'Converter';
         $obj = new $class();
         return $obj->transformToCompare($value, $this);

--- a/Annotation/Compare/Float.php
+++ b/Annotation/Compare/Float.php
@@ -2,8 +2,11 @@
 
 namespace Ibrows\ImportBundle\Annotation\Compare;
 
+@trigger_error('The '.__NAMESPACE__.'\Float annotation is deprecated since version 1.3 and will be removed in 2.0. Use the Field annotation instead.', E_USER_DEPRECATED);
+
 /**
  * @Annotation
+ * @deprecated since version 1.3, to be removed in 2.0. Use the Field annotation instead
  */
 class Float extends AbstractCompare
 {

--- a/Annotation/Compare/Integer.php
+++ b/Annotation/Compare/Integer.php
@@ -2,8 +2,11 @@
 
 namespace Ibrows\ImportBundle\Annotation\Compare;
 
+@trigger_error('The '.__NAMESPACE__.'\Integer annotation is deprecated since version 1.3 and will be removed in 2.0. Use the Field annotation instead.', E_USER_DEPRECATED);
+
 /**
  * @Annotation
+ * @deprecated since version 1.3, to be removed in 2.0. Use the Field annotation instead
  */
 class Integer extends AbstractCompare
 {

--- a/Annotation/Compare/SimpleArray.php
+++ b/Annotation/Compare/SimpleArray.php
@@ -2,8 +2,11 @@
 
 namespace Ibrows\ImportBundle\Annotation\Compare;
 
+@trigger_error('The '.__NAMESPACE__.'\SimpleArray annotation is deprecated since version 1.3 and will be removed in 2.0. Use the Field annotation instead.', E_USER_DEPRECATED);
+
 /**
  * @Annotation
+ * @deprecated since version 1.3, to be removed in 2.0. Use the Field annotation instead
  */
 class SimpleArray extends AbstractCompare
 {

--- a/Annotation/Compare/String.php
+++ b/Annotation/Compare/String.php
@@ -2,8 +2,11 @@
 
 namespace Ibrows\ImportBundle\Annotation\Compare;
 
+@trigger_error('The '.__NAMESPACE__.'\String annotation is deprecated since version 1.3 and will be removed in 2.0. Use the Field annotation instead.', E_USER_DEPRECATED);
+
 /**
  * @Annotation
+ * @deprecated since version 1.3, to be removed in 2.0. Use the Field annotation instead
  */
 class String extends AbstractCompare
 {

--- a/Annotation/Mapping/DateTime.php
+++ b/Annotation/Mapping/DateTime.php
@@ -2,8 +2,11 @@
 
 namespace Ibrows\ImportBundle\Annotation\Mapping;
 
+@trigger_error('The '.__NAMESPACE__.'\DateTime annotation is deprecated since version 1.3 and will be removed in 2.0. Use the Field annotation instead.', E_USER_DEPRECATED);
+
 /**
  * @Annotation
+ * @deprecated since version 1.3, to be removed in 2.0. Use the Field annotation instead
  */
 class DateTime extends AbstractMapping
 {

--- a/Annotation/Mapping/Decimal.php
+++ b/Annotation/Mapping/Decimal.php
@@ -2,8 +2,11 @@
 
 namespace Ibrows\ImportBundle\Annotation\Mapping;
 
+@trigger_error('The '.__NAMESPACE__.'\Decimal annotation is deprecated since version 1.3 and will be removed in 2.0. Use the Field annotation instead.', E_USER_DEPRECATED);
+
 /**
  * @Annotation
+ * @deprecated since version 1.3, to be removed in 2.0. Use the Field annotation instead
  */
 class Decimal extends AbstractMapping
 {

--- a/Annotation/Mapping/Double.php
+++ b/Annotation/Mapping/Double.php
@@ -2,8 +2,11 @@
 
 namespace Ibrows\ImportBundle\Annotation\Mapping;
 
+@trigger_error('The '.__NAMESPACE__.'\Double annotation is deprecated since version 1.3 and will be removed in 2.0. Use the Field annotation instead.', E_USER_DEPRECATED);
+
 /**
  * @Annotation
+ * @deprecated since version 1.3, to be removed in 2.0. Use the Field annotation instead
  */
 class Double extends Float
 {

--- a/Annotation/Mapping/Field.php
+++ b/Annotation/Mapping/Field.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Ibrows\ImportBundle\Annotation\Mapping;
+
+/**
+ * @Annotation
+ * @Target({"PROPERTY"})
+ */
+class Field extends AbstractMapping
+{
+    /**
+     * @Required
+     * @var string
+     */
+    public $type;
+
+    /**
+     * @param array $data An array of key/value parameters
+     *
+     * @throws \BadMethodCallException
+     */
+    public function __construct(array $data)
+    {
+        if (isset($data['value'])) {
+            $data['type'] = $data['value'];
+            unset($data['value']);
+        }
+
+        foreach ($data as $key => $value) {
+            $method = 'set'.str_replace('_', '', ucfirst($key));
+            if (method_exists($this, $method)) {
+                $this->$method($value);
+            } elseif(property_exists($this, $key)) {
+                $this->$key = $value;
+            } else {
+                throw new \BadMethodCallException(sprintf('Unknown property "%s" on annotation "%s".', $key, get_class($this)));
+            }
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * @param string $type
+     */
+    public function setType($type)
+    {
+        $this->type = $type;
+    }
+
+    public function transformToPHP($value)
+    {
+        $class = '\Ibrows\ImportBundle\Annotation\Mapping\\' . ucfirst($this->type);
+        $obj = new $class();
+        $obj->fieldName = $this->fieldName;
+        $obj->getterName = $this->getterName;
+        $obj->setterName = $this->setterName;
+        $obj->ignoreBlank = $this->ignoreBlank;
+        return $obj->transformToPHP($value);
+    }
+
+    public function transformToCompare($value)
+    {
+        $class = '\Ibrows\ImportBundle\Annotation\Mapping\\' . ucfirst($this->type);
+        $obj = new $class();
+        $obj->fieldName = $this->fieldName;
+        $obj->getterName = $this->getterName;
+        $obj->setterName = $this->setterName;
+        $obj->ignoreBlank = $this->ignoreBlank;
+        return $obj->transformToCompare($value);
+    }
+}

--- a/Annotation/Mapping/Float.php
+++ b/Annotation/Mapping/Float.php
@@ -2,8 +2,11 @@
 
 namespace Ibrows\ImportBundle\Annotation\Mapping;
 
+@trigger_error('The '.__NAMESPACE__.'\Float annotation is deprecated since version 1.3 and will be removed in 2.0. Use the Field annotation instead.', E_USER_DEPRECATED);
+
 /**
  * @Annotation
+ * @deprecated since version 1.3, to be removed in 2.0. Use the Field annotation instead
  */
 class Float extends AbstractMapping
 {

--- a/Annotation/Mapping/Integer.php
+++ b/Annotation/Mapping/Integer.php
@@ -2,8 +2,11 @@
 
 namespace Ibrows\ImportBundle\Annotation\Mapping;
 
+@trigger_error('The '.__NAMESPACE__.'\Integer annotation is deprecated since version 1.3 and will be removed in 2.0. Use the Field annotation instead.', E_USER_DEPRECATED);
+
 /**
  * @Annotation
+ * @deprecated since version 1.3, to be removed in 2.0. Use the Field annotation instead
  */
 class Integer extends AbstractMapping
 {

--- a/Annotation/Mapping/SimpleArray.php
+++ b/Annotation/Mapping/SimpleArray.php
@@ -2,8 +2,11 @@
 
 namespace Ibrows\ImportBundle\Annotation\Mapping;
 
+@trigger_error('The '.__NAMESPACE__.'\SimpleArray annotation is deprecated since version 1.3 and will be removed in 2.0. Use the Field annotation instead.', E_USER_DEPRECATED);
+
 /**
  * @Annotation
+ * @deprecated since version 1.3, to be removed in 2.0. Use the Field annotation instead
  */
 class SimpleArray extends AbstractMapping
 {

--- a/Annotation/Mapping/String.php
+++ b/Annotation/Mapping/String.php
@@ -2,8 +2,11 @@
 
 namespace Ibrows\ImportBundle\Annotation\Mapping;
 
+@trigger_error('The '.__NAMESPACE__.'\String annotation is deprecated since version 1.3 and will be removed in 2.0. Use the Field annotation instead.', E_USER_DEPRECATED);
+
 /**
  * @Annotation
+ * @deprecated since version 1.3, to be removed in 2.0. Use the Field annotation instead
  */
 class String extends AbstractMapping
 {

--- a/Converter/AbstractConverter.php
+++ b/Converter/AbstractConverter.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Ibrows\ImportBundle\Converter;
+
+use Ibrows\ImportBundle\Annotation\ResolveByImporterInterface;
+
+abstract class AbstractConverter implements ConverterInterface
+{
+    public function transformToCompare($value, ResolveByImporterInterface $mappingInformation)
+    {
+        return $value;
+    }
+}

--- a/Converter/ConverterInterface.php
+++ b/Converter/ConverterInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Ibrows\ImportBundle\Converter;
+
+use Ibrows\ImportBundle\Annotation\Mapping\MappingInterface;
+use Ibrows\ImportBundle\Annotation\ResolveByImporterInterface;
+
+interface ConverterInterface
+{
+    /**
+     * @param mixed $value
+     * @return mixed
+     */
+    public function transformToPHP($value, MappingInterface $mappingInformation);
+
+    /**
+     * @param mixed $value
+     * @param ResolveByImporterInterface $mappingInformation
+     * @return mixed
+     */
+    public function transformToCompare($value, ResolveByImporterInterface $mappingInformation);
+}

--- a/Converter/DateTimeConverter.php
+++ b/Converter/DateTimeConverter.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Ibrows\ImportBundle\Converter;
+
+use Ibrows\ImportBundle\Annotation\Mapping\MappingInterface;
+
+class DateTimeConverter extends AbstractConverter
+{
+    public function transformToPHP($value, MappingInterface $mappingInformation)
+    {
+        return new \DateTime($value);
+    }
+}

--- a/Converter/DecimalConverter.php
+++ b/Converter/DecimalConverter.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Ibrows\ImportBundle\Converter;
+
+use Ibrows\ImportBundle\Annotation\Mapping\MappingInterface;
+
+class DecimalConverter extends AbstractConverter
+{
+    public function transformToPHP($value, MappingInterface $mappingInformation)
+    {
+        return (double)$value;
+    }
+}

--- a/Converter/DoubleConverter.php
+++ b/Converter/DoubleConverter.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Ibrows\ImportBundle\Converter;
+
+use Ibrows\ImportBundle\Annotation\Mapping\MappingInterface;
+
+class DoubleConverter extends AbstractConverter
+{
+    public function transformToPHP($value, MappingInterface $mappingInformation)
+    {
+        return (double)$value;
+    }
+}

--- a/Converter/FloatConverter.php
+++ b/Converter/FloatConverter.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Ibrows\ImportBundle\Converter;
+
+use Ibrows\ImportBundle\Annotation\Mapping\MappingInterface;
+
+class FloatConverter extends AbstractConverter
+{
+    public function transformToPHP($value, MappingInterface $mappingInformation)
+    {
+        return (float)$value;
+    }
+}

--- a/Converter/IntegerConverter.php
+++ b/Converter/IntegerConverter.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Ibrows\ImportBundle\Converter;
+
+use Ibrows\ImportBundle\Annotation\Mapping\MappingInterface;
+
+class IntegerConverter extends AbstractConverter
+{
+    public function transformToPHP($value, MappingInterface $mappingInformation)
+    {
+        return (int)$value;
+    }
+}

--- a/Converter/SimpleArrayConverter.php
+++ b/Converter/SimpleArrayConverter.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Ibrows\ImportBundle\Converter;
+
+use Ibrows\ImportBundle\Annotation\Mapping\MappingInterface;
+
+class SimpleArrayConverter extends AbstractConverter
+{
+    public function transformToPHP($value, MappingInterface $mappingInformation)
+    {
+        return $value;
+    }
+}

--- a/Converter/StringConverter.php
+++ b/Converter/StringConverter.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Ibrows\ImportBundle\Converter;
+
+use Ibrows\ImportBundle\Annotation\Mapping\MappingInterface;
+
+class StringConverter extends AbstractConverter
+{
+    public function transformToPHP($value, MappingInterface $mappingInformation)
+    {
+        return (string)$value;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -7,9 +7,16 @@
     "require": {
         "php": ">=5.3.0",
         "symfony/framework-bundle": ">=2.1",
-        "ibrows/annotation-reader": "1.*"
+        "ibrows/annotation-reader": "1.*",
+        "doctrine/collections": "~1.2"
     },
     "autoload": {
-        "psr-4": { "Ibrows\\ImportBundle\\": "" }
+        "psr-4": {
+            "Ibrows\\ImportBundle\\": "",
+            "Ibrows\\ImportBundle\\Tests": "tests"
+        }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^5.5"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,6 +10,13 @@
     </php>
 
     <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+            <exclude>tests/Legacy</exclude>
+        </testsuite>
+    </testsuites>
+
+    <testsuites>
         <testsuite name="legacy">
             <directory>tests/Legacy</directory>
         </testsuite>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,11 +14,20 @@
             <directory>tests</directory>
             <exclude>tests/Legacy</exclude>
         </testsuite>
-    </testsuites>
 
-    <testsuites>
         <testsuite name="legacy">
             <directory>tests/Legacy</directory>
         </testsuite>
     </testsuites>
+
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory>.</directory>
+            <exclude>
+                <directory>tests</directory>
+                <directory>vendor</directory>
+                <directory>DependencyInjection</directory>
+            </exclude>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.7/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="tests/autoload.php"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="legacy">
+            <directory>tests/Legacy</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/AbstractImportableEntity.php
+++ b/tests/AbstractImportableEntity.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Ibrows\ImportBundle\Tests;
+
+abstract class AbstractImportableEntity
+{
+    /**
+     * @var int
+     */
+    protected $integerProperty;
+
+    /**
+     * @var float
+     */
+    protected $floatProperty;
+
+    /**
+     * @var double
+     */
+    protected $doubleProperty;
+
+    /**
+     * @var double
+     */
+    protected $decimalProperty;
+
+    /**
+     * @var string
+     */
+    protected $stringProperty;
+
+    /**
+     * @var \DateTime
+     */
+    protected $datetimeProperty;
+
+    /**
+     * @var string
+     */
+    protected $simpleArrayProperty;
+
+    /**
+     * @return int
+     */
+    public function getIntegerProperty()
+    {
+        return $this->integerProperty;
+    }
+
+    /**
+     * @param int $integerProperty
+     */
+    public function setIntegerProperty($integerProperty)
+    {
+        $this->integerProperty = $integerProperty;
+    }
+
+    /**
+     * @return float
+     */
+    public function getFloatProperty()
+    {
+        return $this->floatProperty;
+    }
+
+    /**
+     * @param float $floatProperty
+     */
+    public function setFloatProperty($floatProperty)
+    {
+        $this->floatProperty = $floatProperty;
+    }
+
+    /**
+     * @return float
+     */
+    public function getDoubleProperty()
+    {
+        return $this->doubleProperty;
+    }
+
+    /**
+     * @param float $doubleProperty
+     */
+    public function setDoubleProperty($doubleProperty)
+    {
+        $this->doubleProperty = $doubleProperty;
+    }
+
+    /**
+     * @return float
+     */
+    public function getDecimalProperty()
+    {
+        return $this->decimalProperty;
+    }
+
+    /**
+     * @param float $decimalProperty
+     */
+    public function setDecimalProperty($decimalProperty)
+    {
+        $this->decimalProperty = $decimalProperty;
+    }
+
+    /**
+     * @return string
+     */
+    public function getStringProperty()
+    {
+        return $this->stringProperty;
+    }
+
+    /**
+     * @param string $stringProperty
+     */
+    public function setStringProperty($stringProperty)
+    {
+        $this->stringProperty = $stringProperty;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getDatetimeProperty()
+    {
+        return $this->datetimeProperty;
+    }
+
+    /**
+     * @param mixed $datetimeProperty
+     */
+    public function setDatetimeProperty($datetimeProperty)
+    {
+        $this->datetimeProperty = $datetimeProperty;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSimpleArrayProperty()
+    {
+        return $this->simpleArrayProperty;
+    }
+
+    /**
+     * @param string $simpleArrayProperty
+     */
+    public function setSimpleArrayProperty($simpleArrayProperty)
+    {
+        $this->simpleArrayProperty = $simpleArrayProperty;
+    }
+}

--- a/tests/AbstractRowTest.php
+++ b/tests/AbstractRowTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Ibrows\ImportBundle\Tests;
+
+use Ibrows\ImportBundle\Tests\Stubs\DummyRow;
+
+class AbstractRowTest extends AbstractTestBase
+{
+    public function testFieldAccessor()
+    {
+        $row = new DummyRow([
+            'testRow' => 23
+        ]);
+
+        static::assertTrue($row->has('testRow'));
+        static::assertEquals(23, $row->get('testRow')->getValue());
+    }
+
+    public function testNonExistingFieldAccessor()
+    {
+        $row = new DummyRow([
+            'testRow' => 23
+        ]);
+
+        static::assertFalse($row->has('discordia'));
+        static::assertNull($row->get('discordia'));
+    }
+}

--- a/tests/AbstractTest.php
+++ b/tests/AbstractTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Ibrows\ImportBundle\Tests;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Ibrows\ImportBundle\Annotation\ImportAnnotationReader;
+use Ibrows\ImportBundle\Tests\Stubs\DummyImporter;
+
+class AbstractTest extends \PHPUnit_Framework_TestCase
+{
+    public function createAnnotationReader()
+    {
+        $reader = new AnnotationReader();
+        $ibrowsAnnotationReader = new ImportAnnotationReader();
+        $ibrowsAnnotationReader->setAnnotationReader($reader);
+
+        return $ibrowsAnnotationReader;
+    }
+
+    public function createDummyImporter()
+    {
+        $dummyImporter = new DummyImporter();
+        $dummyImporter->setAnnotationReader($this->createAnnotationReader());
+
+        return $dummyImporter;
+    }
+}

--- a/tests/AbstractTestBase.php
+++ b/tests/AbstractTestBase.php
@@ -6,7 +6,7 @@ use Doctrine\Common\Annotations\AnnotationReader;
 use Ibrows\ImportBundle\Annotation\ImportAnnotationReader;
 use Ibrows\ImportBundle\Tests\Stubs\DummyImporter;
 
-class AbstractTest extends \PHPUnit_Framework_TestCase
+class AbstractTestBase extends \PHPUnit_Framework_TestCase
 {
     public function createAnnotationReader()
     {

--- a/tests/Entities/EntityWithMethodAnnotations.php
+++ b/tests/Entities/EntityWithMethodAnnotations.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Ibrows\ImportBundle\Tests\Entities;
+
+use Ibrows\ImportBundle\Annotation as Import;
+
+class EntityWithMethodAnnotations
+{
+    /**
+     * @var int
+     * @Import\Mapping\Field(type="integer", fieldName="id", ignoreNotExistent=true, ignoreBlank=true)
+     * @Import\Compare\Field(type="integer")
+     * @Import\Identifier\Identifier()
+     */
+    protected $id;
+
+    /**
+     * @var string
+     * @Import\Mapping\Field(type="string", fieldName="name", ignoreNotExistent=true, ignoreBlank=true)
+     * @Import\Compare\Field(type="string")
+     */
+    protected $name;
+
+    public $postBuildCallbackCalled = false;
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param int $id
+     * @return EntityWithMethodAnnotations
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     * @return EntityWithMethodAnnotations
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+        return $this;
+    }
+
+    /**
+     * @Import\Method\PostBuild()
+     */
+    public function postBuildCallback()
+    {
+        $this->postBuildCallbackCalled = true;
+    }
+}

--- a/tests/Entities/EntityWithScalarTypes.php
+++ b/tests/Entities/EntityWithScalarTypes.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Ibrows\ImportBundle\Tests\Entities;
+
+use Ibrows\ImportBundle\Annotation as Import;
+
+class EntityWithScalarTypes
+{
+    /**
+     * @var int
+     * @Import\Mapping\Field(type="integer", fieldName="0")
+     * @Import\Compare\Field(type="integer")
+     * @Import\Identifier\Identifier()
+     */
+    protected $integerProperty;
+
+    /**
+     * @var float
+     * @Import\Mapping\Field(type="float", fieldName="1")
+     * @Import\Compare\Field(type="float")
+     */
+    protected $floatProperty;
+
+    /**
+     * @var double
+     * @Import\Mapping\Field(type="double", fieldName="2")
+     * @Import\Compare\Field(type="double")
+     */
+    protected $doubleProperty;
+
+    /**
+     * @var double
+     * @Import\Mapping\Field(type="decimal", fieldName="3")
+     * @Import\Compare\Field(type="decimal")
+     */
+    protected $decimalProperty;
+
+    /**
+     * @var string
+     * @Import\Mapping\Field(type="string", fieldName="4")
+     * @Import\Compare\Field(type="string")
+     */
+    protected $stringProperty;
+
+    /**
+     * @return int
+     */
+    public function getIntegerProperty()
+    {
+        return $this->integerProperty;
+    }
+
+    /**
+     * @param int $integerProperty
+     */
+    public function setIntegerProperty($integerProperty)
+    {
+        $this->integerProperty = $integerProperty;
+    }
+
+    /**
+     * @return float
+     */
+    public function getFloatProperty()
+    {
+        return $this->floatProperty;
+    }
+
+    /**
+     * @param float $floatProperty
+     */
+    public function setFloatProperty($floatProperty)
+    {
+        $this->floatProperty = $floatProperty;
+    }
+
+    /**
+     * @return float
+     */
+    public function getDoubleProperty()
+    {
+        return $this->doubleProperty;
+    }
+
+    /**
+     * @param float $doubleProperty
+     */
+    public function setDoubleProperty($doubleProperty)
+    {
+        $this->doubleProperty = $doubleProperty;
+    }
+
+    /**
+     * @return float
+     */
+    public function getDecimalProperty()
+    {
+        return $this->decimalProperty;
+    }
+
+    /**
+     * @param float $decimalProperty
+     */
+    public function setDecimalProperty($decimalProperty)
+    {
+        $this->decimalProperty = $decimalProperty;
+    }
+
+    /**
+     * @return string
+     */
+    public function getStringProperty()
+    {
+        return $this->stringProperty;
+    }
+
+    /**
+     * @param string $stringProperty
+     */
+    public function setStringProperty($stringProperty)
+    {
+        $this->stringProperty = $stringProperty;
+    }
+}

--- a/tests/Entities/ImportableEntity.php
+++ b/tests/Entities/ImportableEntity.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Ibrows\ImportBundle\Tests\Entities;
+
+use Ibrows\ImportBundle\Annotation as Import;
+use Ibrows\ImportBundle\Tests\AbstractImportableEntity;
+
+class ImportableEntity extends AbstractImportableEntity
+{
+    /**
+     * @var int
+     * @Import\Mapping\Field(type="integer", fieldName="0")
+     */
+    protected $integerProperty;
+
+    /**
+     * @var float
+     * @Import\Mapping\Field(type="float", fieldName="1")
+     */
+    protected $floatProperty;
+
+    /**
+     * @var double
+     * @Import\Mapping\Field(type="double", fieldName="2")
+     */
+    protected $doubleProperty;
+
+    /**
+     * @var double
+     * @Import\Mapping\Field(type="decimal", fieldName="3")
+     */
+    protected $decimalProperty;
+
+    /**
+     * @var string
+     * @Import\Mapping\Field(type="string", fieldName="4")
+     */
+    protected $stringProperty;
+
+    /**
+     * @var \DateTime
+     * @Import\Mapping\Field(type="dateTime", fieldName="5")
+     */
+    protected $datetimeProperty;
+
+    /**
+     * @var string
+     * @Import\Mapping\Field(type="simpleArray", fieldName="6")
+     */
+    protected $simpleArrayProperty;
+}

--- a/tests/Entities/ImportableEntityWithNoIdentifier.php
+++ b/tests/Entities/ImportableEntityWithNoIdentifier.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Ibrows\ImportBundle\Tests\Entities;
+
+use Ibrows\ImportBundle\Annotation as Import;
+
+class ImportableEntityWithNoIdentifier
+{
+    /**
+     * @var int
+     * @Import\Mapping\Field(type="integer", fieldName="id")
+     * @Import\Compare\Field(type="integer")
+     */
+    protected $id;
+
+    /**
+     * @var string
+     * @Import\Mapping\Field(type="string", fieldName="name")
+     * @Import\Compare\Field(type="string")
+     */
+    protected $name;
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param int $id
+     * @return ImportableEntityWithNoIdentifier
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     * @return ImportableEntityWithNoIdentifier
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+        return $this;
+    }
+}

--- a/tests/Entities/InvalidEntityMethodMissing.php
+++ b/tests/Entities/InvalidEntityMethodMissing.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Ibrows\ImportBundle\Tests\Entities;
+
+use Ibrows\ImportBundle\Annotation as Import;
+
+class InvalidEntityMethodMissing
+{
+    /**
+     * @var int
+     * @Import\Mapping\Field(type="integer", fieldName="id")
+     * @Import\Compare\Field(type="integer")
+     */
+    protected $id;
+
+    /**
+     * @var string
+     * @Import\Mapping\Field(type="string", fieldName="name")
+     * @Import\Compare\Field(type="string")
+     */
+    protected $name;
+}

--- a/tests/Entities/InvalidEntityNoImportAnnotations.php
+++ b/tests/Entities/InvalidEntityNoImportAnnotations.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Ibrows\ImportBundle\Tests\Entities;
+
+class InvalidEntityNoImportAnnotations
+{
+    private $value;
+
+    /**
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * @param mixed $value
+     * @return InvalidEntityNoImportAnnotations
+     */
+    public function setValue($value)
+    {
+        $this->value = $value;
+        return $this;
+    }
+}

--- a/tests/Entities/SimpleImportableEntity.php
+++ b/tests/Entities/SimpleImportableEntity.php
@@ -3,9 +3,8 @@
 namespace Ibrows\ImportBundle\Tests\Entities;
 
 use Ibrows\ImportBundle\Annotation as Import;
-use Ibrows\ImportBundle\Tests\AbstractImportableEntity;
 
-class ImportableEntity extends AbstractImportableEntity
+class SimpleImportableEntity extends ImportableEntity
 {
     /**
      * @var int
@@ -46,7 +45,7 @@ class ImportableEntity extends AbstractImportableEntity
     /**
      * @var \DateTime
      * @Import\Mapping\Field(type="dateTime", fieldName="5")
-     * @Import\Compare\Field(type="dateTime")
+     * @Import\Compare\Exclude()
      */
     protected $datetimeProperty;
 

--- a/tests/ImportHashGeneratorTest.php
+++ b/tests/ImportHashGeneratorTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Ibrows\ImportBundle\Tests;
+
+use Ibrows\ImportBundle\Generator\ImportHashGenerator;
+use Ibrows\ImportBundle\Tests\Entities\EntityWithScalarTypes;
+
+class ImportHashGeneratorTest extends AbstractTestBase
+{
+    public function testHashGeneration()
+    {
+        $hashGenerator = new ImportHashGenerator($this->createAnnotationReader());
+
+        $entity = new EntityWithScalarTypes();
+        $entity->setIntegerProperty(42);
+        $entity->setFloatProperty((float)3.14);
+        $entity->setDoubleProperty((double)2.71);
+        $entity->setDecimalProperty((float)6.28);
+        $entity->setStringProperty('ich bin ein berliner');
+
+        $hash = $hashGenerator->generateFromEntity($entity);
+
+        static::assertEquals('acf0e656a99f944fe41ddf6c636a64be7f73f2b5', $hash);
+    }
+}

--- a/tests/Legacy/Entities/ImportableEntity.php
+++ b/tests/Legacy/Entities/ImportableEntity.php
@@ -3,8 +3,9 @@
 namespace Ibrows\ImportBundle\Tests\Legacy\Entities;
 
 use Ibrows\ImportBundle\Annotation as Import;
+use Ibrows\ImportBundle\Tests\AbstractImportableEntity;
 
-class ImportableEntity
+class ImportableEntity extends AbstractImportableEntity
 {
     /**
      * @var int
@@ -47,116 +48,4 @@ class ImportableEntity
      * @Import\Mapping\SimpleArray(fieldName="6")
      */
     protected $simpleArrayProperty;
-
-    /**
-     * @return int
-     */
-    public function getIntegerProperty()
-    {
-        return $this->integerProperty;
-    }
-
-    /**
-     * @param int $integerProperty
-     */
-    public function setIntegerProperty($integerProperty)
-    {
-        $this->integerProperty = $integerProperty;
-    }
-
-    /**
-     * @return float
-     */
-    public function getFloatProperty()
-    {
-        return $this->floatProperty;
-    }
-
-    /**
-     * @param float $floatProperty
-     */
-    public function setFloatProperty($floatProperty)
-    {
-        $this->floatProperty = $floatProperty;
-    }
-
-    /**
-     * @return float
-     */
-    public function getDoubleProperty()
-    {
-        return $this->doubleProperty;
-    }
-
-    /**
-     * @param float $doubleProperty
-     */
-    public function setDoubleProperty($doubleProperty)
-    {
-        $this->doubleProperty = $doubleProperty;
-    }
-
-    /**
-     * @return float
-     */
-    public function getDecimalProperty()
-    {
-        return $this->decimalProperty;
-    }
-
-    /**
-     * @param float $decimalProperty
-     */
-    public function setDecimalProperty($decimalProperty)
-    {
-        $this->decimalProperty = $decimalProperty;
-    }
-
-    /**
-     * @return string
-     */
-    public function getStringProperty()
-    {
-        return $this->stringProperty;
-    }
-
-    /**
-     * @param string $stringProperty
-     */
-    public function setStringProperty($stringProperty)
-    {
-        $this->stringProperty = $stringProperty;
-    }
-
-    /**
-     * @return mixed
-     */
-    public function getDatetimeProperty()
-    {
-        return $this->datetimeProperty;
-    }
-
-    /**
-     * @param mixed $datetimeProperty
-     */
-    public function setDatetimeProperty($datetimeProperty)
-    {
-        $this->datetimeProperty = $datetimeProperty;
-    }
-
-    /**
-     * @return string
-     */
-    public function getSimpleArrayProperty()
-    {
-        return $this->simpleArrayProperty;
-    }
-
-    /**
-     * @param string $simpleArrayProperty
-     */
-    public function setSimpleArrayProperty($simpleArrayProperty)
-    {
-        $this->simpleArrayProperty = $simpleArrayProperty;
-    }
 }

--- a/tests/Legacy/Entities/ImportableEntity.php
+++ b/tests/Legacy/Entities/ImportableEntity.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Ibrows\ImportBundle\Tests\Legacy\Entities;
+
+use Ibrows\ImportBundle\Annotation as Import;
+
+class ImportableEntity
+{
+    /**
+     * @var int
+     * @Import\Mapping\Integer(fieldName="0")
+     */
+    protected $integerProperty;
+
+    /**
+     * @var float
+     * @Import\Mapping\Float(fieldName="1")
+     */
+    protected $floatProperty;
+
+    /**
+     * @var double
+     * @Import\Mapping\Double(fieldName="2")
+     */
+    protected $doubleProperty;
+
+    /**
+     * @var double
+     * @Import\Mapping\Decimal(fieldName="3")
+     */
+    protected $decimalProperty;
+
+    /**
+     * @var string
+     * @Import\Mapping\String(fieldName="4")
+     */
+    protected $stringProperty;
+
+    /**
+     * @var \DateTime
+     * @Import\Mapping\DateTime(fieldName="5")
+     */
+    protected $datetimeProperty;
+
+    /**
+     * @var string
+     * @Import\Mapping\SimpleArray(fieldName="6")
+     */
+    protected $simpleArrayProperty;
+
+    /**
+     * @return int
+     */
+    public function getIntegerProperty()
+    {
+        return $this->integerProperty;
+    }
+
+    /**
+     * @param int $integerProperty
+     */
+    public function setIntegerProperty($integerProperty)
+    {
+        $this->integerProperty = $integerProperty;
+    }
+
+    /**
+     * @return float
+     */
+    public function getFloatProperty()
+    {
+        return $this->floatProperty;
+    }
+
+    /**
+     * @param float $floatProperty
+     */
+    public function setFloatProperty($floatProperty)
+    {
+        $this->floatProperty = $floatProperty;
+    }
+
+    /**
+     * @return float
+     */
+    public function getDoubleProperty()
+    {
+        return $this->doubleProperty;
+    }
+
+    /**
+     * @param float $doubleProperty
+     */
+    public function setDoubleProperty($doubleProperty)
+    {
+        $this->doubleProperty = $doubleProperty;
+    }
+
+    /**
+     * @return float
+     */
+    public function getDecimalProperty()
+    {
+        return $this->decimalProperty;
+    }
+
+    /**
+     * @param float $decimalProperty
+     */
+    public function setDecimalProperty($decimalProperty)
+    {
+        $this->decimalProperty = $decimalProperty;
+    }
+
+    /**
+     * @return string
+     */
+    public function getStringProperty()
+    {
+        return $this->stringProperty;
+    }
+
+    /**
+     * @param string $stringProperty
+     */
+    public function setStringProperty($stringProperty)
+    {
+        $this->stringProperty = $stringProperty;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getDatetimeProperty()
+    {
+        return $this->datetimeProperty;
+    }
+
+    /**
+     * @param mixed $datetimeProperty
+     */
+    public function setDatetimeProperty($datetimeProperty)
+    {
+        $this->datetimeProperty = $datetimeProperty;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSimpleArrayProperty()
+    {
+        return $this->simpleArrayProperty;
+    }
+
+    /**
+     * @param string $simpleArrayProperty
+     */
+    public function setSimpleArrayProperty($simpleArrayProperty)
+    {
+        $this->simpleArrayProperty = $simpleArrayProperty;
+    }
+}

--- a/tests/Legacy/Entities/ImportableEntity.php
+++ b/tests/Legacy/Entities/ImportableEntity.php
@@ -10,42 +10,50 @@ class ImportableEntity extends AbstractImportableEntity
     /**
      * @var int
      * @Import\Mapping\Integer(fieldName="0")
+     * @Import\Compare\Integer()
+     * @Import\Identifier\Identifier()
      */
     protected $integerProperty;
 
     /**
      * @var float
      * @Import\Mapping\Float(fieldName="1")
+     * @Import\Compare\Float()
      */
     protected $floatProperty;
 
     /**
      * @var double
      * @Import\Mapping\Double(fieldName="2")
+     * @Import\Compare\Double()
      */
     protected $doubleProperty;
 
     /**
      * @var double
      * @Import\Mapping\Decimal(fieldName="3")
+     * @Import\Compare\Decimal()
      */
     protected $decimalProperty;
 
     /**
      * @var string
      * @Import\Mapping\String(fieldName="4")
+     * @Import\Compare\String()
      */
     protected $stringProperty;
 
     /**
      * @var \DateTime
      * @Import\Mapping\DateTime(fieldName="5")
+     * @Import\Compare\DateTime()
      */
     protected $datetimeProperty;
 
     /**
      * @var string
      * @Import\Mapping\SimpleArray(fieldName="6")
+     * @Import\Compare\SimpleArray()
      */
     protected $simpleArrayProperty;
 }

--- a/tests/Legacy/Entities/SimpleImportableEntity.php
+++ b/tests/Legacy/Entities/SimpleImportableEntity.php
@@ -1,11 +1,10 @@
 <?php
 
-namespace Ibrows\ImportBundle\Tests\Entities;
+namespace Ibrows\ImportBundle\Tests\Legacy\Entities;
 
 use Ibrows\ImportBundle\Annotation as Import;
-use Ibrows\ImportBundle\Tests\AbstractImportableEntity;
 
-class ImportableEntity extends AbstractImportableEntity
+class SimpleImportableEntity extends ImportableEntity
 {
     /**
      * @var int
@@ -46,7 +45,7 @@ class ImportableEntity extends AbstractImportableEntity
     /**
      * @var \DateTime
      * @Import\Mapping\Field(type="dateTime", fieldName="5")
-     * @Import\Compare\Field(type="dateTime")
+     * @Import\Compare\Exclude()
      */
     protected $datetimeProperty;
 

--- a/tests/Legacy/MappingTest.php
+++ b/tests/Legacy/MappingTest.php
@@ -3,6 +3,7 @@
 namespace Ibrows\ImportBundle\Tests\Legacy;
 
 use Ibrows\ImportBundle\Tests\AbstractTestBase;
+use Ibrows\ImportBundle\Tests\Legacy\Entities\SimpleImportableEntity;
 use Ibrows\ImportBundle\Tests\Legacy\Entities\ImportableEntity;
 use Ibrows\ImportBundle\Tests\Stubs\DummyRow;
 
@@ -53,5 +54,86 @@ class MappingTest extends AbstractTestBase
         static::assertEquals(6.28, $newEntity->getDecimalProperty());
         static::assertEquals('ich bin ein berliner', $newEntity->getStringProperty());
         static::assertEquals('2017-01-23', $newEntity->getDatetimeProperty()->format('Y-m-d'));
+    }
+
+    /**
+     * @expectedException \Ibrows\ImportBundle\Exception\NotAllRowsGivenException
+     */
+    public function testEmptyValueMapping()
+    {
+        $dummyImporter = $this->createDummyImporter();
+        $dummyImporter->process([
+            new DummyRow([
+                '',
+                '',
+                '',
+                '',
+                '',
+                ''
+            ])
+        ], ImportableEntity::class);
+    }
+
+    public function testMappingWithExistingChangedEntity()
+    {
+        $existingEntity = new ImportableEntity();
+        $existingEntity->setIntegerProperty(42);
+
+        $dummyImporter = $this->createDummyImporter();
+        $dummyImporter->setExistingEntities([
+            'integerProperty' => [
+                42 => $existingEntity
+            ]
+        ]);
+        $dummyImporter->process([
+            new DummyRow([
+                '42',
+                '3.14',
+                '2.71',
+                '6.28',
+                'ich bin ein berliner',
+                '2017-01-23',
+                'abc,def,xyz'
+            ])
+        ], ImportableEntity::class);
+
+        static::assertEquals(0, $dummyImporter->getResultBag()->countSkipped());
+        static::assertEquals(0, $dummyImporter->getResultBag()->countNew());
+        static::assertEquals(1, $dummyImporter->getResultBag()->countChanged());
+        static::assertEquals(1, $dummyImporter->getResultBag()->countProcessed());
+    }
+
+    public function testMappingWithExistingEqualEntity()
+    {
+        $existingEntity = new SimpleImportableEntity();
+        $existingEntity->setIntegerProperty(42);
+        $existingEntity->setFloatProperty((float)3.14);
+        $existingEntity->setDoubleProperty((double)2.71);
+        $existingEntity->setDecimalProperty((float)6.28);
+        $existingEntity->setStringProperty('ich bin ein berliner');
+        $existingEntity->setSimpleArrayProperty('abc,def,xyz');
+
+        $dummyImporter = $this->createDummyImporter();
+        $dummyImporter->setExistingEntities([
+            'integerProperty' => [
+                42 => $existingEntity
+            ]
+        ]);
+        $dummyImporter->process([
+            new DummyRow([
+                '42',
+                '3.14',
+                '2.71',
+                '6.28',
+                'ich bin ein berliner',
+                '2017-01-23',
+                'abc,def,xyz'
+            ])
+        ], SimpleImportableEntity::class);
+
+        static::assertEquals(1, $dummyImporter->getResultBag()->countSkipped());
+        static::assertEquals(0, $dummyImporter->getResultBag()->countNew());
+        static::assertEquals(0, $dummyImporter->getResultBag()->countChanged());
+        static::assertEquals(1, $dummyImporter->getResultBag()->countProcessed());
     }
 }

--- a/tests/Legacy/MappingTest.php
+++ b/tests/Legacy/MappingTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Ibrows\ImportBundle\Tests\Legacy;
+
+use Ibrows\ImportBundle\Tests\AbstractTest;
+use Ibrows\ImportBundle\Tests\Legacy\Entities\ImportableEntity;
+use Ibrows\ImportBundle\Tests\Stubs\DummyRow;
+
+class MappingTest extends AbstractTest
+{
+    public function testIntegerMapping()
+    {
+        $dummyImporter = $this->createDummyImporter();
+        $dummyImporter->process([
+            new DummyRow([
+                '42',
+                '3.14',
+                '2.71',
+                '6.28',
+                'ich bin ein berliner',
+                '2017-01-23',
+                'abc,def,xyz'
+            ])
+        ], ImportableEntity::class);
+
+        static::assertCount(1, $dummyImporter->getResultBag()->getNew());
+
+        /** @var ImportableEntity $newEntity */
+        $newEntity = $dummyImporter->getResultBag()->getNew()[0];
+
+        static::assertInstanceOf(ImportableEntity::class, $newEntity);
+
+        static::assertInternalType('integer', $newEntity->getIntegerProperty());
+        static::assertInternalType('float', $newEntity->getFloatProperty());
+        static::assertInternalType('double', $newEntity->getDoubleProperty());
+        static::assertInternalType('double', $newEntity->getDecimalProperty());
+        static::assertInternalType('string', $newEntity->getStringProperty());
+        static::assertInstanceOf(\DateTime::class, $newEntity->getDatetimeProperty());
+        static::assertInternalType('string', $newEntity->getSimpleArrayProperty());
+
+
+        static::assertEquals(42, $newEntity->getIntegerProperty());
+        static::assertEquals(3.14, $newEntity->getFloatProperty());
+        static::assertEquals(2.71, $newEntity->getDoubleProperty());
+        static::assertEquals(6.28, $newEntity->getDecimalProperty());
+        static::assertEquals('ich bin ein berliner', $newEntity->getStringProperty());
+        static::assertEquals('2017-01-23', $newEntity->getDatetimeProperty()->format('Y-m-d'));
+    }
+}

--- a/tests/Legacy/MappingTest.php
+++ b/tests/Legacy/MappingTest.php
@@ -8,6 +8,14 @@ use Ibrows\ImportBundle\Tests\Stubs\DummyRow;
 
 class MappingTest extends AbstractTest
 {
+    protected function setUp()
+    {
+        if (PHP_MAJOR_VERSION >= 7) {
+            $this->markTestSkipped('Legacy annotations won\'t work with PHP 7 or higher, skipping those tests');
+        }
+        parent::setUp();
+    }
+
     public function testIntegerMapping()
     {
         $dummyImporter = $this->createDummyImporter();

--- a/tests/Legacy/MappingTest.php
+++ b/tests/Legacy/MappingTest.php
@@ -2,11 +2,11 @@
 
 namespace Ibrows\ImportBundle\Tests\Legacy;
 
-use Ibrows\ImportBundle\Tests\AbstractTest;
+use Ibrows\ImportBundle\Tests\AbstractTestBase;
 use Ibrows\ImportBundle\Tests\Legacy\Entities\ImportableEntity;
 use Ibrows\ImportBundle\Tests\Stubs\DummyRow;
 
-class MappingTest extends AbstractTest
+class MappingTest extends AbstractTestBase
 {
     protected function setUp()
     {

--- a/tests/MappingTest.php
+++ b/tests/MappingTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Ibrows\ImportBundle\Tests;
+
+use Ibrows\ImportBundle\Tests\Entities\ImportableEntity;
+use Ibrows\ImportBundle\Tests\Stubs\DummyRow;
+
+class MappingTest extends AbstractTestBase
+{
+
+    public function testIntegerMapping()
+    {
+        $dummyImporter = $this->createDummyImporter();
+        $dummyImporter->process([
+            new DummyRow([
+                '42',
+                '3.14',
+                '2.71',
+                '6.28',
+                'ich bin ein berliner',
+                '2017-01-23',
+                'abc,def,xyz'
+            ])
+        ], ImportableEntity::class);
+
+        static::assertCount(1, $dummyImporter->getResultBag()->getNew());
+
+        /** @var ImportableEntity $newEntity */
+        $newEntity = $dummyImporter->getResultBag()->getNew()[0];
+
+        static::assertInstanceOf(ImportableEntity::class, $newEntity);
+
+        static::assertInternalType('integer', $newEntity->getIntegerProperty());
+        static::assertInternalType('float', $newEntity->getFloatProperty());
+        static::assertInternalType('double', $newEntity->getDoubleProperty());
+        static::assertInternalType('double', $newEntity->getDecimalProperty());
+        static::assertInternalType('string', $newEntity->getStringProperty());
+        static::assertInstanceOf(\DateTime::class, $newEntity->getDatetimeProperty());
+        static::assertInternalType('string', $newEntity->getSimpleArrayProperty());
+
+
+        static::assertEquals(42, $newEntity->getIntegerProperty());
+        static::assertEquals(3.14, $newEntity->getFloatProperty());
+        static::assertEquals(2.71, $newEntity->getDoubleProperty());
+        static::assertEquals(6.28, $newEntity->getDecimalProperty());
+        static::assertEquals('ich bin ein berliner', $newEntity->getStringProperty());
+        static::assertEquals('2017-01-23', $newEntity->getDatetimeProperty()->format('Y-m-d'));
+    }
+}

--- a/tests/MappingTest.php
+++ b/tests/MappingTest.php
@@ -2,12 +2,17 @@
 
 namespace Ibrows\ImportBundle\Tests;
 
+use Ibrows\ImportBundle\Tests\Entities\EntityWithMethodAnnotations;
 use Ibrows\ImportBundle\Tests\Entities\ImportableEntity;
+use Ibrows\ImportBundle\Tests\Entities\ImportableEntityWithNoIdentifier;
+use Ibrows\ImportBundle\Tests\Entities\InvalidEntityMethodMissing;
+use Ibrows\ImportBundle\Tests\Entities\InvalidEntityNoImportAnnotations;
+use Ibrows\ImportBundle\Tests\Entities\SimpleImportableEntity;
+use Ibrows\ImportBundle\Tests\Stubs\DummyImporterWithNullBuilder;
 use Ibrows\ImportBundle\Tests\Stubs\DummyRow;
 
 class MappingTest extends AbstractTestBase
 {
-
     public function testIntegerMapping()
     {
         $dummyImporter = $this->createDummyImporter();
@@ -45,5 +50,168 @@ class MappingTest extends AbstractTestBase
         static::assertEquals(6.28, $newEntity->getDecimalProperty());
         static::assertEquals('ich bin ein berliner', $newEntity->getStringProperty());
         static::assertEquals('2017-01-23', $newEntity->getDatetimeProperty()->format('Y-m-d'));
+    }
+
+    /**
+     * @expectedException \Ibrows\ImportBundle\Exception\NotAllRowsGivenException
+     */
+    public function testEmptyValueMapping()
+    {
+        $dummyImporter = $this->createDummyImporter();
+        $dummyImporter->process([
+            new DummyRow([
+                '',
+                '',
+                '',
+                '',
+                '',
+                ''
+            ])
+        ], ImportableEntity::class);
+    }
+
+    public function testNullBuilderReturnHandling()
+    {
+        $dummyImporter = new DummyImporterWithNullBuilder();
+        $dummyImporter->setAnnotationReader($this->createAnnotationReader());
+        $dummyImporter->process([
+            new DummyRow([
+                '',
+                '',
+                '',
+                '',
+                '',
+                ''
+            ])
+        ], ImportableEntity::class);
+
+        static::assertEquals(1, $dummyImporter->getResultBag()->countSkipped());
+    }
+
+    public function testMappingWithExistingChangedEntity()
+    {
+        $existingEntity = new ImportableEntity();
+        $existingEntity->setIntegerProperty(42);
+
+        $dummyImporter = $this->createDummyImporter();
+        $dummyImporter->setExistingEntities([
+            'integerProperty' => [
+                42 => $existingEntity
+            ]
+        ]);
+        $dummyImporter->process([
+            new DummyRow([
+                '42',
+                '3.14',
+                '2.71',
+                '6.28',
+                'ich bin ein berliner',
+                '2017-01-23',
+                'abc,def,xyz'
+            ])
+        ], ImportableEntity::class);
+
+        static::assertCount(1, $dummyImporter->getResultBag()->getChanged());
+    }
+
+    public function testMappingWithExistingEqualEntity()
+    {
+        $existingEntity = new SimpleImportableEntity();
+        $existingEntity->setIntegerProperty(42);
+        $existingEntity->setFloatProperty((float)3.14);
+        $existingEntity->setDoubleProperty((double)2.71);
+        $existingEntity->setDecimalProperty((float)6.28);
+        $existingEntity->setStringProperty('ich bin ein berliner');
+        $existingEntity->setSimpleArrayProperty('abc,def,xyz');
+
+        $dummyImporter = $this->createDummyImporter();
+        $dummyImporter->setExistingEntities([
+            'integerProperty' => [
+                42 => $existingEntity
+            ]
+        ]);
+        $dummyImporter->process([
+            new DummyRow([
+                '42',
+                '3.14',
+                '2.71',
+                '6.28',
+                'ich bin ein berliner',
+                '2017-01-23',
+                'abc,def,xyz'
+            ])
+        ], SimpleImportableEntity::class);
+
+        static::assertEquals(1, $dummyImporter->getResultBag()->countSkipped());
+        static::assertEquals(0, $dummyImporter->getResultBag()->countNew());
+        static::assertEquals(0, $dummyImporter->getResultBag()->countChanged());
+        static::assertEquals(1, $dummyImporter->getResultBag()->countProcessed());
+    }
+
+
+    /**
+     * @expectedException \Ibrows\ImportBundle\Exception\ImportIdentifierNotFoundException
+     */
+    public function testMappingOfNonIdentifierEntity()
+    {
+        $existingEntity = new ImportableEntityWithNoIdentifier();
+        $existingEntity->setId(42);
+        $existingEntity->setName('Fritz');
+
+        $dummyImporter = $this->createDummyImporter();
+        $dummyImporter->setExistingEntities([
+            'id' => [
+                42 => $existingEntity
+            ]
+        ]);
+        $dummyImporter->process([
+            new DummyRow([
+                'id' => '42',
+                'name' => 'Hans',
+            ])
+        ], ImportableEntityWithNoIdentifier::class);
+    }
+
+    /**
+     * @expectedException \Ibrows\ImportBundle\Exception\MethodNotFoundException
+     */
+    public function testMappingOfEntityWithNoSetters()
+    {
+        $dummyImporter = $this->createDummyImporter();
+        $dummyImporter->process([
+            new DummyRow([
+                'id' => '42',
+                'name' => 'Hans',
+            ])
+        ], InvalidEntityMethodMissing::class);
+    }
+
+    /**
+     * @expectedException \Ibrows\ImportBundle\Exception\NoImportAnnotationsFoundException
+     */
+    public function testMappingOfEntityWithNoAnnotations()
+    {
+        $dummyImporter = $this->createDummyImporter();
+        $dummyImporter->process([
+            new DummyRow([
+                'id' => '42',
+                'name' => 'Hans',
+            ])
+        ], InvalidEntityNoImportAnnotations::class);
+    }
+
+    public function testMappingWithMethodAnnotations()
+    {
+        $dummyImporter = $this->createDummyImporter();
+        $dummyImporter->process([
+            new DummyRow([
+                'id' => '42',
+                'name' => 'Hans',
+            ])
+        ], EntityWithMethodAnnotations::class);
+
+        static::assertEquals(1, $dummyImporter->getResultBag()->countNew());
+
+        static::assertTrue($dummyImporter->getResultBag()->getNew()[0]->postBuildCallbackCalled);
     }
 }

--- a/tests/Stubs/DummyField.php
+++ b/tests/Stubs/DummyField.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Ibrows\ImportBundle\Tests\Stubs;
+
+use Ibrows\ImportBundle\Row\Field\AbstractField;
+
+class DummyField extends AbstractField
+{
+    public function __construct($name, $value)
+    {
+        $this->name = $name;
+        $this->value = $value;
+    }
+}

--- a/tests/Stubs/DummyImporter.php
+++ b/tests/Stubs/DummyImporter.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Ibrows\ImportBundle\Tests\Stubs;
+
+use Ibrows\ImportBundle\AbstractImporter;
+
+class DummyImporter extends AbstractImporter
+{
+    public function process($data, $className)
+    {
+        foreach($data as $i => $row) {
+            $this->buildAndCompareEntity(
+                $i,
+                $row,
+                $className
+            );
+        }
+    }
+
+    protected function getAlreadyExistingEntity($entity)
+    {
+        // this method would call the entity manager, we're not interested in that here
+        return null;
+    }
+}

--- a/tests/Stubs/DummyImporter.php
+++ b/tests/Stubs/DummyImporter.php
@@ -6,20 +6,44 @@ use Ibrows\ImportBundle\AbstractImporter;
 
 class DummyImporter extends AbstractImporter
 {
+    private $existingEntities = [];
+
+    /**
+     * @param array $existingEntities
+     * @return DummyImporter
+     */
+    public function setExistingEntities(array $existingEntities)
+    {
+        $this->existingEntities = $existingEntities;
+        return $this;
+    }
+
     public function process($data, $className)
     {
-        foreach($data as $i => $row) {
+        foreach ($data as $i => $row) {
             $this->buildAndCompareEntity(
                 $i,
                 $row,
                 $className
             );
+            $this->getResultBag()->setCountProcessed($this->getResultBag()->countProcessed() + 1);
         }
+    }
+
+    private function isExistingEntity($propertyName, $searchValue)
+    {
+        return array_key_exists($propertyName, $this->existingEntities)
+            && is_array($this->existingEntities[$propertyName])
+            && array_key_exists($searchValue, $this->existingEntities[$propertyName]);
     }
 
     protected function getAlreadyExistingEntity($entity)
     {
-        // this method would call the entity manager, we're not interested in that here
+        foreach ($this->getIdentifiersForEntity($entity) as $propertyName => $searchValue){
+            if ($searchValue && $this->isExistingEntity($propertyName, $searchValue)) {
+                return $this->existingEntities[$propertyName][$searchValue];
+            }
+        }
         return null;
     }
 }

--- a/tests/Stubs/DummyImporterWithNullBuilder.php
+++ b/tests/Stubs/DummyImporterWithNullBuilder.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Ibrows\ImportBundle\Tests\Stubs;
+
+use Ibrows\ImportBundle\Row\RowInterface;
+
+class DummyImporterWithNullBuilder extends DummyImporter
+{
+    protected function buildEntity($key, RowInterface $row, $entity, $fromAlreadyExisting = false)
+    {
+        return null;
+    }
+}

--- a/tests/Stubs/DummyRow.php
+++ b/tests/Stubs/DummyRow.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Ibrows\ImportBundle\Tests\Stubs;
+
+use Ibrows\ImportBundle\Row\AbstractRow;
+
+class DummyRow extends AbstractRow
+{
+    public function __construct(array $data)
+    {
+        $fields = [];
+        foreach($data as $name => $value) {
+            $fields[] = new DummyField((string)$name, $value);
+        }
+
+        $this->setFields($fields);
+    }
+}

--- a/tests/autoload.php
+++ b/tests/autoload.php
@@ -1,0 +1,7 @@
+<?php
+
+use Doctrine\Common\Annotations\AnnotationRegistry;
+
+$loader = require __DIR__.'/../vendor/autoload.php';
+
+AnnotationRegistry::registerLoader([$loader, 'loadClass']);


### PR DESCRIPTION
This is regarding issue #1, the import bundle can now be used with PHP 7.0+ by using the newly introduced field annotation. The field annotation uses converters so the annotations and the actual conversion logic is separated.